### PR TITLE
Fix script terminating too soon

### DIFF
--- a/mediatek_fix.sh
+++ b/mediatek_fix.sh
@@ -58,7 +58,6 @@ if [[ "$1" == "--apply" ]]; then
         sed -i '/^usb:v0489pE111/,/^$/ s/^\([^#]\)/# \1/' "$file"
     done
 
-    exit 0
 fi
 
 
@@ -75,7 +74,6 @@ if [[ "$1" == "--undo" ]]; then
     done
 
     echo -e "${GREEN}Undo complete.${NC}"
-    exit 0
 fi
 
 # update hwdb


### PR DESCRIPTION
Removed two "exit 0" lines that caused the script to terminate before updating the hardware database