### PR TITLE
Add ThinkStation P8 to affected devices list

### DIFF
--- a/affecteddevices.md
+++ b/affecteddevices.md
@@ -4,3 +4,4 @@ The following list includes all affected devices reported by the community. If y
 ## Lenovo
 * IdeaPad Pro 5 14AKP10
 * Yoga Pro 7 14ASP10
+* ThinkStation P8 (AMD platform）


### PR DESCRIPTION
This script works on P8 with Ubuntu24.04/RHEL10/F43