### PR TITLE
Adds Legion Pro 5 16AFR10 to affected devices

### DIFF
--- a/affecteddevices.md
+++ b/affecteddevices.md
@@ -6,3 +6,4 @@ The following list includes all affected devices reported by the community. If y
 * Yoga Pro 7 14ASP10
 * ThinkStation P8 (AMD platform）
 * Legion Pro 5 16IAX10
+* Legion Pro 5 16AFR10


### PR DESCRIPTION
Adds "Legion Pro 5 16AFR10" to the list of affected devices
reported by the community. This ensures users are aware if
this model is experiencing similar issues.
