### PR TITLE
Add Lenovo IdeaPad Slim 5 16AKP10 to affected devices list

### DIFF
--- a/affecteddevices.md
+++ b/affecteddevices.md
@@ -2,6 +2,7 @@
 The following list includes all affected devices reported by the community. If you found this page, are affected and don't see your device on this list, please open a pull request!
 
 ## Lenovo
+* IdeaPad Slim 5 16AKP10
 * IdeaPad Pro 5 14AKP10
 * Yoga Pro 7 14ASP10
 * ThinkStation P8 (AMD platform）


### PR DESCRIPTION
Adds "IdeaPad Slim 5 16AKP10" to the list of affected devices
having mediatek 7925e chipset. This ensures users are aware if
this model is experiencing similar issues.